### PR TITLE
Fix resolveExitReason bug and add command array, env, and OutputStream API

### DIFF
--- a/src/ExitReason.php
+++ b/src/ExitReason.php
@@ -7,6 +7,7 @@ namespace SMWks\SuperProcess;
 enum ExitReason: string
 {
     case Normal = 'NORMAL';
+    case Error = 'ERROR';
     case Signal = 'SIGNAL';
     case Killed = 'KILLED';
     case Unknown = 'UNKNOWN';

--- a/src/OutputStream.php
+++ b/src/OutputStream.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SMWks\SuperProcess;
+
+enum OutputStream: string
+{
+    case Stdout = 'stdout';
+    case Stderr = 'stderr';
+}

--- a/src/SuperProcess.php
+++ b/src/SuperProcess.php
@@ -170,7 +170,7 @@ class SuperProcess
 
     public function run(): void
     {
-        if ($this->command === null && ! $this->closure instanceof \Closure) {
+        if ($this->command === null && ! $this->closure instanceof Closure) {
             throw new ProcessException('No command or closure configured. Call command() or closure() before run().');
         }
 
@@ -258,7 +258,7 @@ class SuperProcess
             }
 
             // Heartbeat
-            if ($this->heartbeatInterval > 0 && $this->heartbeatCallback instanceof \Closure && time() - $lastHeartbeat >= $this->heartbeatInterval) {
+            if ($this->heartbeatInterval > 0 && $this->heartbeatCallback instanceof Closure && time() - $lastHeartbeat >= $this->heartbeatInterval) {
                 ($this->heartbeatCallback)($this);
                 $lastHeartbeat = time();
             }
@@ -359,7 +359,7 @@ class SuperProcess
         if ($pid === 0) {
             // Child process
             fclose($parentSocket);
-            assert($this->closure instanceof \Closure);
+            assert($this->closure instanceof Closure);
             try {
                 ($this->closure)($childSocket);
             } finally {
@@ -403,7 +403,7 @@ class SuperProcess
 
         if ($stream === $child->ipcChannel) {
             $this->dispatchChildMessage($child, $data);
-        } elseif ($this->onChildOutputCallback instanceof \Closure) {
+        } elseif ($this->onChildOutputCallback instanceof Closure) {
             $outputStream = $stream === $child->stdout ? OutputStream::Stdout : OutputStream::Stderr;
             ($this->onChildOutputCallback)($child, $data, $outputStream);
         }
@@ -411,7 +411,7 @@ class SuperProcess
 
     protected function dispatchChildMessage(Child $child, string $rawData): void
     {
-        if (! $this->onChildMessageCallback instanceof \Closure) {
+        if (! $this->onChildMessageCallback instanceof Closure) {
             return;
         }
 
@@ -429,7 +429,7 @@ class SuperProcess
 
     protected function dispatchChildSignalToAll(int $signal): void
     {
-        if (! $this->onChildSignalCallback instanceof \Closure) {
+        if (! $this->onChildSignalCallback instanceof Closure) {
             return;
         }
 
@@ -478,7 +478,7 @@ class SuperProcess
             $exitedChild->exitCode = $exitCode;
             $exitedChild->exitReason = $exitReason;
 
-            if ($this->onChildExitCallback instanceof \Closure) {
+            if ($this->onChildExitCallback instanceof Closure) {
                 ($this->onChildExitCallback)($exitedChild, $exitReason);
             }
         }
@@ -526,7 +526,7 @@ class SuperProcess
 
     protected function shutdown(): void
     {
-        if ($this->onShutdownCallback instanceof \Closure) {
+        if ($this->onShutdownCallback instanceof Closure) {
             ($this->onShutdownCallback)($this);
         }
 
@@ -565,7 +565,7 @@ class SuperProcess
 
     protected function fireOnChildCreate(Child $child): void
     {
-        if ($this->onChildCreateCallback instanceof \Closure) {
+        if ($this->onChildCreateCallback instanceof Closure) {
             ($this->onChildCreateCallback)($child, $child->createReason);
         }
     }

--- a/src/SuperProcess.php
+++ b/src/SuperProcess.php
@@ -9,7 +9,11 @@ use SMWks\SuperProcess\Exceptions\ProcessException;
 
 class SuperProcess
 {
-    protected ?string $command = null;
+    /** @var string|list<string>|null */
+    protected string|array|null $command = null;
+
+    /** @var array<string, string>|null */
+    protected ?array $env = null;
 
     protected ?Closure $closure = null;
 
@@ -44,9 +48,18 @@ class SuperProcess
 
     protected mixed $sigWritePipe = null;
 
-    public function command(string $command): static
+    /** @param string|list<string> $command */
+    public function command(string|array $command): static
     {
         $this->command = $command;
+
+        return $this;
+    }
+
+    /** @param array<string, string> $vars */
+    public function env(array $vars): static
+    {
+        $this->env = $vars;
 
         return $this;
     }
@@ -87,7 +100,7 @@ class SuperProcess
 
     public function scaleDown(): static
     {
-        $active = array_filter($this->children, fn (Child $c) => ! $c->terminating);
+        $active = array_filter($this->children, fn (Child $c): bool => ! $c->terminating);
 
         if (count($active) > $this->minChildren) {
             $child = reset($active);
@@ -294,11 +307,15 @@ class SuperProcess
             3 => ['pipe', 'w'],  // fd3    – structured messages (onChildMessage)
         ];
 
+        $command = $this->command;
+        assert($command !== null);
+
         $pipes = [];
-        $process = proc_open((string) $this->command, $descriptors, $pipes);
+        $process = proc_open($command, $descriptors, $pipes, null, $this->env);
 
         if (! is_resource($process)) {
-            throw new ProcessException(sprintf('Failed to start command: %s', $this->command));
+            $display = is_array($command) ? implode(' ', $command) : $command;
+            throw new ProcessException(sprintf('Failed to start command: %s', $display));
         }
 
         /** @var array{0: resource, 1: resource, 2: resource, 3: resource} $pipes */
@@ -387,8 +404,8 @@ class SuperProcess
         if ($stream === $child->ipcChannel) {
             $this->dispatchChildMessage($child, $data);
         } elseif ($this->onChildOutputCallback instanceof \Closure) {
-            // stdout or stderr
-            ($this->onChildOutputCallback)($child, $data);
+            $outputStream = $stream === $child->stdout ? OutputStream::Stdout : OutputStream::Stderr;
+            ($this->onChildOutputCallback)($child, $data, $outputStream);
         }
     }
 
@@ -470,7 +487,7 @@ class SuperProcess
     protected function resolveExitReason(int $status): ExitReason
     {
         if (pcntl_wifexited($status)) {
-            return pcntl_wexitstatus($status) === 0 ? ExitReason::Normal : ExitReason::Normal;
+            return pcntl_wexitstatus($status) === 0 ? ExitReason::Normal : ExitReason::Error;
         }
 
         if (pcntl_wifsignaled($status)) {
@@ -555,6 +572,6 @@ class SuperProcess
 
     protected function findChildByStream(mixed $stream): ?Child
     {
-        return array_find($this->children, fn ($child) => in_array($stream, [$child->stdout, $child->stderr, $child->ipcChannel], true));
+        return array_find($this->children, fn ($child): bool => in_array($stream, [$child->stdout, $child->stderr, $child->ipcChannel], true));
     }
 }

--- a/tests/Feature.php
+++ b/tests/Feature.php
@@ -4,6 +4,7 @@ use SMWks\SuperProcess\Child;
 use SMWks\SuperProcess\CreateReason;
 use SMWks\SuperProcess\Exceptions\ProcessException;
 use SMWks\SuperProcess\ExitReason;
+use SMWks\SuperProcess\OutputStream;
 use SMWks\SuperProcess\ProcessSignal;
 use SMWks\SuperProcess\SuperProcess;
 
@@ -35,9 +36,19 @@ it('has the expected CreateReason cases', function (): void {
 
 it('has the expected ExitReason cases', function (): void {
     expect(ExitReason::Normal->name)->toBe('Normal')
+        ->and(ExitReason::Error->name)->toBe('Error')
         ->and(ExitReason::Signal->name)->toBe('Signal')
         ->and(ExitReason::Killed->name)->toBe('Killed')
         ->and(ExitReason::Unknown->name)->toBe('Unknown');
+});
+
+// ---------------------------------------------------------------------------
+// OutputStream enum
+// ---------------------------------------------------------------------------
+
+it('has the expected OutputStream cases', function (): void {
+    expect(OutputStream::Stdout->value)->toBe('stdout')
+        ->and(OutputStream::Stderr->value)->toBe('stderr');
 });
 
 // ---------------------------------------------------------------------------
@@ -113,6 +124,8 @@ it('returns static from fluent configuration methods', function (): void {
     $noop = function (): void {};
 
     expect($sp->command('echo hello'))->toBeInstanceOf(SuperProcess::class)
+        ->and($sp->command(['echo', 'hello']))->toBeInstanceOf(SuperProcess::class)
+        ->and($sp->env(['FOO' => 'bar']))->toBeInstanceOf(SuperProcess::class)
         ->and($sp->scaleLimits(1, 3))->toBeInstanceOf(SuperProcess::class)
         ->and($sp->heartbeat(30, $noop))->toBeInstanceOf(SuperProcess::class)
         ->and($sp->onChildCreate($noop))->toBeInstanceOf(SuperProcess::class)


### PR DESCRIPTION
Closes #1

## Bug fix

**`resolveExitReason()` returned `ExitReason::Normal` for non-zero exits** — both branches of the ternary were identical. Added `ExitReason::Error` and now return it when `pcntl_wexitstatus($status) !== 0`.

## API additions

**`command(string|array $command)`** — accepts an array and passes it directly to `proc_open()`, avoiding shell injection and handling paths with spaces correctly.

**`env(array $vars)`** — passes an environment variable array to `proc_open()`'s `$env` argument, enabling per-worker overrides without modifying the parent process environment.

**`onChildOutput` third argument** — added `OutputStream` enum (`Stdout`/`Stderr`) as a third parameter to the output callback, so callers can route stdout and stderr to different log levels or channels.

## Notes

- `test:typos` requires `aspell` which is not installed in the local environment; all other checks pass
- The `scaleDown called twice` integration test has a pre-existing flakiness when run in the full suite (confirmed failing on master as well) — unrelated to these changes